### PR TITLE
Kart data goodness

### DIFF
--- a/api/resources.py
+++ b/api/resources.py
@@ -137,18 +137,19 @@ class KartDataResource(ModelResource):
     class Meta:
         queryset = KartData.objects.all()
         limit = 0
-        max_limit = 1000
+        max_limit = 5000
 
         resource_name = 'KartData'
-        allowed_methods = ['post', 'get', 'patch', 'delete']
+        allowed_methods = ['get']
         authentication = Authentication()
         authorization = Authorization()
         always_return_data = True
+        fields = ('Latitude', 'Longitude')
         filtering = {
             "ianlegg" : ALL_WITH_RELATIONS,
             "ids": ALL,                         #for specific anleggsIDs =  /api/v1/KartData/?ids=800843,800844,800845&format=json
-            "Latitude": ALL_WITH_RELATIONS,     #usage: /api/v1/KartData/?format=json
-            "Longitude": ALL_WITH_RELATIONS
+            "Latitude": ALL,     #usage: /api/v1/KartData/?format=json
+            "Longitude": ALL
         }
     def build_filters(self, filters=None):
         if filters is None:

--- a/api/resources.py
+++ b/api/resources.py
@@ -93,6 +93,11 @@ class KommuneResource(ModelResource):
         }
 
 class KartAnleggResource(ModelResource):
+    anleggstype = fields.ToOneField(AnleggTypeResource, 'Anleggstype', full=True)
+    anleggsklasse = fields.ToOneField(AnleggsKlasseResource, 'Anleggsklasse', full=True)
+    anleggskategori = fields.ToOneField(AnleggsKategoriResource, 'Anleggskategori', full=True)
+    kommune = fields.ToOneField(KommuneResource, 'kommune', full=True)
+    anleggstatus = fields.ToOneField(AnleggStatusResource, 'anleggStatus', full=True)
     class Meta:
         queryset = Idrettsanlegg.objects.all()
         resource_name = 'idrettsanlegg'
@@ -101,7 +106,28 @@ class KartAnleggResource(ModelResource):
         authorization = Authorization()
         always_return_data = True
         filtering = {
-            'id' : ALL
+            "byggeaar": ALL_WITH_RELATIONS,  #?byggeaar__gt=2011&byggeaar__lt=2013&format=json
+            "anleggDriver": ALL_WITH_RELATIONS,
+            "anleggEier": ALL_WITH_RELATIONS,
+            "anleggsnavn": ALL_WITH_RELATIONS,
+            "anleggsNummer": ALL_WITH_RELATIONS,
+            "areal": ALL_WITH_RELATIONS,
+            "bredde": ALL_WITH_RELATIONS,
+            "indratt": ALL_WITH_RELATIONS,
+            "lengde": ALL_WITH_RELATIONS,
+            "nummer1": ALL_WITH_RELATIONS,
+            "ombyggeaar": ALL_WITH_RELATIONS,
+            "tildelt": ALL_WITH_RELATIONS,
+            "utbetalt": ALL_WITH_RELATIONS,
+            "uu": ALL_WITH_RELATIONS,
+
+
+            "ids" : ALL_WITH_RELATIONS,
+            "kommune": ALL_WITH_RELATIONS,
+            "anleggstype": ALL_WITH_RELATIONS,
+            "anleggsklasse": ALL_WITH_RELATIONS,
+            "anleggskategori": ALL_WITH_RELATIONS,
+            "anleggstatus": ALL_WITH_RELATIONS
         }
         serializer = PrettyJSONSerializer()
 
@@ -111,7 +137,7 @@ class KartDataResource(ModelResource):
     class Meta:
         queryset = KartData.objects.all()
         limit = 0
-        max_limit = 4000
+        max_limit = 1000
 
         resource_name = 'KartData'
         allowed_methods = ['post', 'get', 'patch', 'delete']

--- a/idrettsanlegginorge/urls.py
+++ b/idrettsanlegginorge/urls.py
@@ -17,7 +17,7 @@ from django.conf.urls import url, include
 from django.contrib import admin
 from idrettsanlegg import views
 from tastypie.api import Api
-from api.resources import IdrettsanleggResource, AnleggTypeResource, KartDataResource, AnleggStatusResource, AnleggsKategoriResource, KommuneResource, FylkeResource, AnleggsKlasseResource, FreeTextIdrettResource
+from api.resources import IdrettsanleggResource, AnleggTypeResource, KartDataResource, AnleggStatusResource, AnleggsKategoriResource, KommuneResource, FylkeResource, AnleggsKlasseResource, FreeTextIdrettResource, KartAnleggResource
 
 v1_api = Api(api_name='v1')
 v1_api.register(IdrettsanleggResource())
@@ -29,6 +29,8 @@ v1_api.register(AnleggStatusResource())
 v1_api.register(KommuneResource())
 v1_api.register(FylkeResource())
 v1_api.register(FreeTextIdrettResource())
+v1_api.register(KartAnleggResource())
+
 
 
 urlpatterns = [


### PR DESCRIPTION
/api/v1/KartData/?format=json&limit=1000 (<3 sec)
Is now pretty fast, and allows for the same filtering as Idrettsanlegg by prepending ianlegg.
e.g. /api/v1/KartData/?ianlegg__byggeaar__istartswith=200&format=json (for all anlegg built 2000-2009)

Also added a way of looking up multiple anlegg by ids, /api/v1/KartData/?ids=800843,800844,800845,800846&format=json (Not sure if useful)

Stripped the json to the bare minimum with the map in mid, keeping only Lat & Long. A call to Idrettsanlegg using the provided URI (in the JSON) should be used to fetch all the information about a Idrettsanlegg. 
